### PR TITLE
convert head/lib

### DIFF
--- a/src/state-history/StateHistoryPostgresActionReader.ts
+++ b/src/state-history/StateHistoryPostgresActionReader.ts
@@ -17,12 +17,12 @@ export class StateHistoryPostgresActionReader extends AbstractActionReader {
 
   public async getHeadBlockNumber(): Promise<number> {
     const statusRow = await this.db.fill_status.findOne()
-    return statusRow.head
+    return parseInt(statusRow.head)
   }
 
   public async getLastIrreversibleBlockNumber(): Promise<number> {
     const statusRow = await this.db.fill_status.findOne()
-    return statusRow.irreversible
+    return parseInt(statusRow.irreversible)
   }
 
   public async getBlock(blockNumber: number): Promise<StateHistoryPostgresBlock> {

--- a/src/state-history/StateHistoryPostgresActionReader.ts
+++ b/src/state-history/StateHistoryPostgresActionReader.ts
@@ -17,12 +17,12 @@ export class StateHistoryPostgresActionReader extends AbstractActionReader {
 
   public async getHeadBlockNumber(): Promise<number> {
     const statusRow = await this.db.fill_status.findOne()
-    return parseInt(statusRow.head)
+    return Number(statusRow.head)
   }
 
   public async getLastIrreversibleBlockNumber(): Promise<number> {
     const statusRow = await this.db.fill_status.findOne()
-    return parseInt(statusRow.irreversible)
+    return Number(statusRow.irreversible)
   }
 
   public async getBlock(blockNumber: number): Promise<StateHistoryPostgresBlock> {


### PR DESCRIPTION
The data coming out of Postgres needs to be converted to integers to allow demux to continue when it reaches what it thinks the current head block is.