### PR TITLE
Make `EosPayload` a generic interface

### DIFF
--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -19,11 +19,11 @@ export interface EosAuthorization {
   permission: string
 }
 
-export interface EosPayload {
+export interface EosPayload<ActionStruct = any> {
   account: string
   actionIndex: number
   authorization: EosAuthorization[]
-  data: any
+  data: ActionStruct
   name: string
   producer: string
   transactionId: string


### PR DESCRIPTION
This change allows users to pass in a type for the `EosPayload.data` property when defining their updaters/effects, which should correspond to the Blockchain contract action's struct:

```typescript
interface AssetStruct {
  amount: number
  symbol: string
}

const apply = async (state: any, payload: EosPayload<AssetStruct>, blockInfo: BlockInfo) => {
  state.save({
    amount: payload.data.amount,
    symbol: payload.data.symbol,
  })
}
```