### PR TITLE
Context Free Actions and Data

### DIFF
--- a/__mocks__/eosjs.js
+++ b/__mocks__/eosjs.js
@@ -16,6 +16,7 @@ class Api {
     }
     return returnVals
   }
+  get abiProvider() { return {} }
 }
 
 class JsonRpc {}

--- a/__mocks__/massive.js
+++ b/__mocks__/massive.js
@@ -15,7 +15,7 @@ const massive = () => {
       },
       block_info: {
         findOne: () => ({
-          block_index: 4,
+          block_num: 4,
           block_id: 'qwerty1234',
           previous: 'qwerty1233',
           timestamp: new Date().toString(),
@@ -24,13 +24,11 @@ const massive = () => {
     },
     query: () => ([
       {
-        account: 'token',
-        name: 'transfer',
-        authorization: [{
-          actor: 'useraaaaaaaa',
-          permission: 'active',
-        }],
-        data: [100, 100, 100, 100, 100, 100, 100],
+        act_account: 'token',
+        act_name: 'transfer',
+        act_data: [100, 100, 100, 100, 100, 100, 100],
+        actor: 'useraaaaaaaa',
+        permission: 'active',
       }
     ]),
   }

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "massive": "5.8.0",
     "mongodb": "^3.1.3",
     "node-fetch": "^2.3.0",
+    "pg-monitor": "^1.1.0",
     "request": "^2.87.0",
     "request-promise-native": "^1.0.5"
   },

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -32,7 +32,7 @@ export interface EosPayload<ActionStruct = any> {
   notifiedAccounts?: string[]
   isContextFree?: boolean
   isInline?: boolean
-  contextFreeData?: Uint8Array[]
+  contextFreeData?: Buffer[]
   transactionActions?: TransactionActions
 }
 

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -21,15 +21,26 @@ export interface EosAuthorization {
 
 export interface EosPayload<ActionStruct = any> {
   account: string
-  actionIndex: number
   authorization: EosAuthorization[]
   data: ActionStruct
   name: string
-  producer: string
   transactionId: string
+  actionIndex?: number
+  actionOrdinal?: number
+  producer?: string
   notifiedAccounts?: string[]
+  isContextFree?: boolean
+  isInline?: boolean
+  contextFreeData?: Uint8Array[]
+  transactionActions?: TransactionActions
 }
 
 export interface EosAction extends Action {
   payload: EosPayload
+}
+
+export interface TransactionActions {
+  contextFreeActions: EosAction[]
+  actions: EosAction[]
+  inlineActions: EosAction[]
 }

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -12,6 +12,7 @@ export interface MongoActionReaderOptions extends ActionReaderOptions {
 export interface StateHistoryPostgresActionReaderOptions extends ActionReaderOptions {
   massiveConfig: any
   dbSchema?: string
+  enablePgMonitor?: boolean
 }
 
 export interface EosAuthorization {

--- a/src/readers/state-history/StateHistoryPostgresAbiProvider.test.ts
+++ b/src/readers/state-history/StateHistoryPostgresAbiProvider.test.ts
@@ -14,7 +14,8 @@ describe('StateHistoryPostgresAbiProvider', () => {
         },
       }
     }
-    stateHistoryPostgresAbiProvider = new StateHistoryPostgresAbiProvider(massiveMock)
+    stateHistoryPostgresAbiProvider = new StateHistoryPostgresAbiProvider()
+    stateHistoryPostgresAbiProvider.massiveInstance = massiveMock
   })
   it('retrieves abis', async () => {
     const abi = await stateHistoryPostgresAbiProvider.getRawAbi('test')

--- a/src/readers/state-history/StateHistoryPostgresAbiProvider.ts
+++ b/src/readers/state-history/StateHistoryPostgresAbiProvider.ts
@@ -1,23 +1,25 @@
 import { ApiInterfaces } from 'eosjs'
 
 export class StateHistoryPostgresAbiProvider implements ApiInterfaces.AbiProvider {
-  private db: any
-
-  constructor(
-    private massiveInstance: any,
-    private dbSchema: string = 'chain',
-  ) {
-    this.db = this.massiveInstance[this.dbSchema]
-  }
+  public blockNumber: number = 0
+  public massiveInstance: any = {}
+  public dbSchema: string = 'chain'
 
   public async getRawAbi(accountName: string): Promise<ApiInterfaces.BinaryAbi> {
-    const accountRow = await this.db.account.findOne({ name: accountName })
-
-    const binaryAbi: ApiInterfaces.BinaryAbi = {
+    const db = this.massiveInstance[this.dbSchema]
+    const accountRow = await db.account.findOne(
+      {
+        'name': accountName,
+        'block_num <': this.blockNumber,
+      },
+      { order: [{
+        field: 'block_num',
+        direction: 'desc',
+      }]}
+    )
+    return {
       accountName: accountRow.name,
       abi: accountRow.abi,
     }
-
-    return binaryAbi
   }
 }

--- a/src/readers/state-history/StateHistoryPostgresActionReader.ts
+++ b/src/readers/state-history/StateHistoryPostgresActionReader.ts
@@ -30,14 +30,14 @@ export class StateHistoryPostgresActionReader extends AbstractActionReader {
 
   public async getBlock(blockNumber: number): Promise<StateHistoryPostgresBlock> {
     const pgBlockInfo = await this.db.block_info.findOne({
-      block_index: blockNumber,
+      block_num: blockNumber,
     })
 
     // Uses ${<var-name>} for JS substitutions and $<var-name> for massivejs substitutions.
     const query = `
-      SELECT at.account,
-             at.name,
-             at.data,
+      SELECT at.act_account,
+             at.act_name,
+             at.act_data,
              at.transaction_id,
              at.action_ordinal,
              at.creator_action_ordinal,

--- a/src/readers/state-history/StateHistoryPostgresBlock.test.ts
+++ b/src/readers/state-history/StateHistoryPostgresBlock.test.ts
@@ -6,21 +6,23 @@ describe('StateHistoryPostgresBlock', () => {
   beforeEach(async () => {
     stateHistoryPostgresBlock = new StateHistoryPostgresBlock(
       {
-        block_index: 4,
+        block_num: 4,
         block_id: 'qwerty1234',
         previous: 'qwerty1233',
         timestamp: new Date('2018-08-12').toString(),
       },
       [{
-        account: 'token',
-        action_index: 1,
+        act_account: 'token',
+        act_name: 'transfer',
+        action_ordinal: 1,
         transaction_id: '12345',
         receipt_receiver: 'userbbbbbbbb',
         producer: 'eosio',
-        name: 'transfer',
         actor: 'useraaaaaaaa',
         permission: 'active',
+        context_free: false,
         data: [100, 100, 100, 100, 100, 100, 100],
+        partial_context_free_data: [],
       }],
       {},
     )
@@ -37,43 +39,54 @@ describe('StateHistoryPostgresBlock', () => {
   })
 
   it('collects actions from blocks', () => {
-    expect(stateHistoryPostgresBlock.actions).toEqual([{
-      type: 'token::transfer',
+    const actions = [{
       payload: {
         account: 'token',
-        name: 'transfer',
-        producer: 'eosio',
+        actionOrdinal: 1,
         authorization: [{
           actor: 'useraaaaaaaa',
-          permission: 'active',
+          permission: 'active'
         }],
+        contextFreeData: [],
         data: {
           from: 'useraaaaaaaa',
-          to: 'userbbbbbbbb',
           memo: '',
           quantity: '0.0100 EOS',
+          to: 'userbbbbbbbb'
         },
-        actionIndex: 1,
-        transactionId: '12345',
+        isContextFree: false,
+        isInline: false,
+        name: 'transfer',
         notifiedAccounts: ['userbbbbbbbb'],
-      }
-    }])
+        producer: 'eosio',
+        transactionActions: {
+          actions: [] as any[],
+          contextFreeActions: [],
+          inlineActions: []
+        },
+        transactionId: '12345'
+      },
+      type: 'token::transfer'
+    }]
+    actions[0].payload.transactionActions.actions.push(actions[0])
+
+    expect(stateHistoryPostgresBlock.actions).toEqual(actions)
   })
 
   it('handles blockNumber as string', async () => {
     stateHistoryPostgresBlock = new StateHistoryPostgresBlock(
       {
-        block_index: '4',
+        block_num: '4',
         block_id: 'qwerty1234',
         previous: 'qwerty1233',
         timestamp: new Date('2018-08-12').toString(),
       },
       [{
-        account: 'token',
-        action_index: 1,
+        act_account: 'token',
+        act_name: 'transfer',
+        action_ordinal: 1,
         transaction_id: '12345',
         receipt_receiver: 'userbbbbbbbb',
-        name: 'transfer',
         actor: 'useraaaaaaaa',
         permission: 'active',
         data: [100, 100, 100, 100, 100, 100, 100],

--- a/src/readers/state-history/StateHistoryPostgresBlock.ts
+++ b/src/readers/state-history/StateHistoryPostgresBlock.ts
@@ -99,17 +99,17 @@ export class StateHistoryPostgresBlock implements Block {
     }
   }
 
-  private async getDeserializedAction(api: Api, actionTrace: any) {
+  private async getDeserializedAction(eosApi: Api, actionTrace: any) {
     const serializedAction = this.createSerializedAction(actionTrace)
     let deserializedAction: any
     try {
-      [deserializedAction] = await api.deserializeActions([serializedAction])
+      [deserializedAction] = await eosApi.deserializeActions([serializedAction])
     } catch (err) {
       if (err.message.startsWith('Unknown action')) {
-        api.cachedAbis.delete(actionTrace.act_account)
-        api.contracts.delete(actionTrace.act_account)
+        eosApi.cachedAbis.delete(actionTrace.act_account)
+        eosApi.contracts.delete(actionTrace.act_account)
         try {
-          [deserializedAction] = await api.deserializeActions([serializedAction])
+          [deserializedAction] = await eosApi.deserializeActions([serializedAction])
         } catch (err) {
           if (err.message.startsWith('Unknown action')) {
             console.warn(`Action ${actionTrace.act_account}::${actionTrace.act_name} does not have an ABI; skipped`)

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "es6",
+    "target": "es2016",
     "module": "commonjs",
     "declaration": true,
     "outDir": "dist",

--- a/yarn.lock
+++ b/yarn.lock
@@ -271,7 +271,7 @@ ansi-escapes@^3.0.0:
   resolved "https://registry.yarnpkg.com/ansi-escapes/-/ansi-escapes-3.2.0.tgz#8780b98ff9dbf5638152d1f1fe5c1d7b4442976b"
   integrity sha512-cBhpre4ma+U0T1oM5fXg7Dy1Jw7zzwv7lt/GoCpr+hDQJoYnKVPLL4dCvSEFMmQurOQvSrwT7SL/DAlhBI97RQ==
 
-ansi-regex@^2.0.0:
+ansi-regex@^2.0.0, ansi-regex@^2.1.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-2.1.1.tgz#c3b33ab5ee360d86e0e628f0468ae7ef27d654df"
   integrity sha1-w7M6te42DYbg5ijwRorn7yfWVN8=
@@ -858,6 +858,18 @@ class-utils@^0.3.5:
     isobject "^3.0.0"
     static-extend "^0.1.1"
 
+cli-color@1.3.0:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/cli-color/-/cli-color-1.3.0.tgz#cd2ec212efbd1a0eeb5b017f17d4e2d15e91420f"
+  integrity sha512-XmbLr8MzgOup/sPHF4nOZerCOcL7rD7vKWpEl0axUsMAY+AEimOhYva1ksskWqkLGY/bjR9h7Cfbr+RrJRfmTQ==
+  dependencies:
+    ansi-regex "^2.1.1"
+    d "1"
+    es5-ext "^0.10.46"
+    es6-iterator "^2.0.3"
+    memoizee "^0.4.14"
+    timers-ext "^0.1.5"
+
 cliui@^4.0.0:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/cliui/-/cliui-4.1.0.tgz#348422dbe82d800b3022eef4f6ac10bf2e4d1b49"
@@ -1019,6 +1031,13 @@ cssstyle@^1.0.0:
   integrity sha512-7DYm8qe+gPx/h77QlCyFmX80+fGaE/6A/Ekl0zaszYOubvySO2saYFdQ78P29D0UsULxFKCetDGNaNRUdSF+2A==
   dependencies:
     cssom "0.3.x"
+
+d@1:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/d/-/d-1.0.0.tgz#754bb5bfe55451da69a58b94d45f4c5b0462d58f"
+  integrity sha1-dUu1v+VUUdpppYuU1F9MWwRi1Y8=
+  dependencies:
+    es5-ext "^0.10.9"
 
 dashdash@^1.12.0:
   version "1.14.1"
@@ -1264,6 +1283,42 @@ es-to-primitive@^1.2.0:
     is-date-object "^1.0.1"
     is-symbol "^1.0.2"
 
+es5-ext@^0.10.14, es5-ext@^0.10.35, es5-ext@^0.10.45, es5-ext@^0.10.46, es5-ext@^0.10.9, es5-ext@~0.10.14, es5-ext@~0.10.2, es5-ext@~0.10.46:
+  version "0.10.50"
+  resolved "https://registry.yarnpkg.com/es5-ext/-/es5-ext-0.10.50.tgz#6d0e23a0abdb27018e5ac4fd09b412bc5517a778"
+  integrity sha512-KMzZTPBkeQV/JcSQhI5/z6d9VWJ3EnQ194USTUwIYZ2ZbpN8+SGXQKt1h68EX44+qt+Fzr8DO17vnxrw7c3agw==
+  dependencies:
+    es6-iterator "~2.0.3"
+    es6-symbol "~3.1.1"
+    next-tick "^1.0.0"
+
+es6-iterator@^2.0.1, es6-iterator@^2.0.3, es6-iterator@~2.0.3:
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/es6-iterator/-/es6-iterator-2.0.3.tgz#a7de889141a05a94b0854403b2d0a0fbfa98f3b7"
+  integrity sha1-p96IkUGgWpSwhUQDstCg+/qY87c=
+  dependencies:
+    d "1"
+    es5-ext "^0.10.35"
+    es6-symbol "^3.1.1"
+
+es6-symbol@^3.1.1, es6-symbol@~3.1.1:
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/es6-symbol/-/es6-symbol-3.1.1.tgz#bf00ef4fdab6ba1b46ecb7b629b4c7ed5715cc77"
+  integrity sha1-vwDvT9q2uhtG7Le2KbTH7VcVzHc=
+  dependencies:
+    d "1"
+    es5-ext "~0.10.14"
+
+es6-weak-map@^2.0.2:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/es6-weak-map/-/es6-weak-map-2.0.2.tgz#5e3ab32251ffd1538a1f8e5ffa1357772f92d96f"
+  integrity sha1-XjqzIlH/0VOKH45f+hNXdy+S2W8=
+  dependencies:
+    d "1"
+    es5-ext "^0.10.14"
+    es6-iterator "^2.0.1"
+    es6-symbol "^3.1.1"
+
 escape-html@~1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/escape-html/-/escape-html-1.0.3.tgz#0258eae4d3d0c0974de1c169188ef0051d1d1988"
@@ -1315,6 +1370,14 @@ etag@~1.8.1:
   version "1.8.1"
   resolved "https://registry.yarnpkg.com/etag/-/etag-1.8.1.tgz#41ae2eeb65efa62268aebfea83ac7d79299b0887"
   integrity sha1-Qa4u62XvpiJorr/qg6x9eSmbCIc=
+
+event-emitter@^0.3.5:
+  version "0.3.5"
+  resolved "https://registry.yarnpkg.com/event-emitter/-/event-emitter-0.3.5.tgz#df8c69eef1647923c7157b9ce83840610b02cc39"
+  integrity sha1-34xp7vFkeSPHFXuc6DhAYQsCzDk=
+  dependencies:
+    d "1"
+    es5-ext "~0.10.14"
 
 evp_bytestokey@^1.0.3:
   version "1.0.3"
@@ -2109,6 +2172,11 @@ is-primitive@^2.0.0:
   resolved "https://registry.yarnpkg.com/is-primitive/-/is-primitive-2.0.0.tgz#207bab91638499c07b2adf240a41a87210034575"
   integrity sha1-IHurkWOEmcB7Kt8kCkGochADRXU=
 
+is-promise@^2.1:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/is-promise/-/is-promise-2.1.0.tgz#79a2a9ece7f096e80f36d2b2f3bc16c1ff4bf3fa"
+  integrity sha1-eaKp7OfwlugPNtKy87wWwf9L8/o=
+
 is-regex@^1.0.4:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/is-regex/-/is-regex-1.0.4.tgz#5517489b547091b0930e095654ced25ee97e9491"
@@ -2774,6 +2842,13 @@ lru-cache@^4.0.1:
     pseudomap "^1.0.2"
     yallist "^2.1.2"
 
+lru-queue@0.1:
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/lru-queue/-/lru-queue-0.1.0.tgz#2738bd9f0d3cf4f84490c5736c48699ac632cda3"
+  integrity sha1-Jzi9nw089PhEkMVzbEhpmsYyzaM=
+  dependencies:
+    es5-ext "~0.10.2"
+
 make-error@1.x:
   version "1.3.5"
   resolved "https://registry.yarnpkg.com/make-error/-/make-error-1.3.5.tgz#efe4e81f6db28cadd605c70f29c831b58ef776c8"
@@ -2844,6 +2919,20 @@ mem@^1.1.0:
   integrity sha1-Xt1StIXKHZAP5kiVUFOZoN+kX3Y=
   dependencies:
     mimic-fn "^1.0.0"
+
+memoizee@^0.4.14:
+  version "0.4.14"
+  resolved "https://registry.yarnpkg.com/memoizee/-/memoizee-0.4.14.tgz#07a00f204699f9a95c2d9e77218271c7cd610d57"
+  integrity sha512-/SWFvWegAIYAO4NQMpcX+gcra0yEZu4OntmUdrBaWrJncxOqAziGFlHxc7yjKVK2uu3lpPW27P27wkR82wA8mg==
+  dependencies:
+    d "1"
+    es5-ext "^0.10.45"
+    es6-weak-map "^2.0.2"
+    event-emitter "^0.3.5"
+    is-promise "^2.1"
+    lru-queue "0.1"
+    next-tick "1"
+    timers-ext "^0.1.5"
 
 memory-pager@^1.0.2:
   version "1.5.0"
@@ -3072,6 +3161,11 @@ negotiator@0.6.1:
   version "0.6.1"
   resolved "https://registry.yarnpkg.com/negotiator/-/negotiator-0.6.1.tgz#2b327184e8992101177b28563fb5e7102acd0ca9"
   integrity sha1-KzJxhOiZIQEXeyhWP7XnECrNDKk=
+
+next-tick@1, next-tick@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/next-tick/-/next-tick-1.0.0.tgz#ca86d1fe8828169b0120208e3dc8424b9db8342c"
+  integrity sha1-yobR/ogoFpsBICCOPchCS524NCw=
 
 node-fetch@^2.3.0:
   version "2.3.0"
@@ -3416,6 +3510,13 @@ pg-minify@1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/pg-minify/-/pg-minify-1.0.0.tgz#aaae109c1ef3e4cc8f4080d758d48a37af7bc758"
   integrity sha512-NqXLLNhJli14c15tk350qVYK+ElzlN9gf4atexFTmQy09wAJHfmk0W57OGCJZba2k+ngU+FlqdnAKYjeE3BIww==
+
+pg-monitor@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/pg-monitor/-/pg-monitor-1.1.0.tgz#748c69d6ab2ebff6bd929737be72cb2adb4bc1e3"
+  integrity sha512-qeXsToBc62lBdxlqKhDQClJdimz4hv/6GuzfA3Mpm00LZJdJ1BxfWTuvYLn7v3h3Y3JFa5dg1Xdjr7CdOcNUdw==
+  dependencies:
+    cli-color "1.3.0"
 
 pg-pool@^2.0.4:
   version "2.0.6"
@@ -4323,6 +4424,14 @@ through@2:
   version "2.3.8"
   resolved "https://registry.yarnpkg.com/through/-/through-2.3.8.tgz#0dd4c9ffaabc357960b1b724115d7e0e86a2e1f5"
   integrity sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=
+
+timers-ext@^0.1.5:
+  version "0.1.7"
+  resolved "https://registry.yarnpkg.com/timers-ext/-/timers-ext-0.1.7.tgz#6f57ad8578e07a3fb9f91d9387d65647555e25c6"
+  integrity sha512-b85NUNzTSdodShTIbky6ZF02e8STtVVfD+fu4aXXShEELpozH+bCpJLYMPZbsABN2wDH7fJpqIoXxJpzbf0NqQ==
+  dependencies:
+    es5-ext "~0.10.46"
+    next-tick "1"
 
 tmpl@1.0.x:
   version "1.0.4"


### PR DESCRIPTION
## Main updates:

This PR centers around context free functionality.

- The `EosAction` interface now has (and are utilized by the `StateHistoryPostgresActionReader`):
  - `contextFreeData`: An array of buffers. All actions within the same transaction will have the same context free data
  - `transactionActions`: Access to other actions within the same transaction, separated by `contextFreeActions`, `actions`, and `inlineActions`
  - `isInline` and `isContextFree` boolean properties

## Supporting updates:
- Field names for querying the pg-fill database are updated to correspond to the latest version
- The `StateHistoryPostgresAbiProvider` is now aware of the current block, so it can return the correct historical ABI if necessary during replay or initial startup
- The eosjs `Api` instance is maintained between blocks in order to take advantage of ABI caching

## Other things:
- You can now enable postgres query debugging by setting the `enablePgMonitor` boolean option to true when instantiating the `StateHistoryPostgresActionReader`