### PR TITLE
StateHistoryPostgresActionReader performance fixes

### DIFF
--- a/src/readers/state-history/StateHistoryPostgresAbiProvider.ts
+++ b/src/readers/state-history/StateHistoryPostgresAbiProvider.ts
@@ -10,7 +10,7 @@ export class StateHistoryPostgresAbiProvider implements ApiInterfaces.AbiProvide
     const accountRow = await db.account.findOne(
       {
         'name': accountName,
-        'block_num <': this.blockNumber,
+        'block_num <=': this.blockNumber,
       },
       { order: [{
         field: 'block_num',

--- a/src/readers/state-history/StateHistoryPostgresBlock.test.ts
+++ b/src/readers/state-history/StateHistoryPostgresBlock.test.ts
@@ -24,6 +24,7 @@ describe('StateHistoryPostgresBlock', () => {
         data: [100, 100, 100, 100, 100, 100, 100],
         partial_context_free_data: [],
       }],
+      [],
       {},
     )
     await stateHistoryPostgresBlock.parseActions()
@@ -91,6 +92,7 @@ describe('StateHistoryPostgresBlock', () => {
         permission: 'active',
         data: [100, 100, 100, 100, 100, 100, 100],
       }],
+      [],
       {},
     )
     await stateHistoryPostgresBlock.parseActions()

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "es2016",
+    "target": "es2017",
     "module": "commonjs",
     "declaration": true,
     "outDir": "dist",


### PR DESCRIPTION
- Previously, when there were multiple actions from the same contract in a block, and the ABI has not been cached yet for that contract, the `StateHistoryPostgresAbiProvider` would make a query to get the ABI for every single action from that contract in that block. This PR changes this so that the ABI is only loaded once per contract.
- When joining on the `transaction_traces` table to get context free data, this becomes very slow when there are many rows of actions- over 5 minutes for 30k rows. By splitting out the context free query, the total time to fetch all data becomes 350ms for 30k rows.