### PR TITLE
Fix npm publish

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,8 +27,9 @@ jobs:
       provider: script
       skip_cleanup: true
       script: "./scripts/publish-edge.sh"
-#      on:
-#        branch: develop
+      on:
+        all_branches: true
+#          branch: develop
   - stage: publish-latest
     name: Publish @latest to NPM
     script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,8 +7,9 @@ before_install:
 - npm install -g typescript
 stages:
 - test
-- name: publish-edge
-  if: "(NOT type IN (pull_request)) AND (branch = develop)"
+- publish-edge
+#- name: publish-edge
+#  if: "(NOT type IN (pull_request)) AND (branch = develop)"
 - name: publish-latest
   if: branch =~ ^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)$
 jobs:
@@ -26,8 +27,8 @@ jobs:
       provider: script
       skip_cleanup: true
       script: "./scripts/publish-edge.sh"
-      on:
-        branch: develop
+#      on:
+#        branch: develop
   - stage: publish-latest
     name: Publish @latest to NPM
     script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,8 @@
 sudo: false
 language: node_js
-node_js:
-- 10.0.0
-before_install:
-- npm i -g npm@6.4.1
-- npm install -g typescript
+#before_install:
+#- npm i -g npm@6.4.1
+#- npm install -g typescript
 stages:
 - test
 - publish-edge
@@ -17,12 +15,12 @@ jobs:
   - stage: test
     name: Lint and Test
     script:
-    - npm run lint
-    - npm run test
+    - yarn lint
+    - yarn test
   - stage: publish-edge
     name: Publish @edge to NPM
     script:
-    - npm run build
+    - yarn build
     deploy:
       provider: script
       skip_cleanup: true
@@ -33,7 +31,7 @@ jobs:
   - stage: publish-latest
     name: Publish @latest to NPM
     script:
-    - npm run build
+    - yarn build
     deploy:
       provider: script
       skip_cleanup: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ sudo: false
 language: node_js
 stages:
 - test
-- publish-edge
 - name: publish-edge
   if: "(NOT type IN (pull_request)) AND (branch = develop)"
 - name: publish-latest

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,10 @@
 sudo: false
 language: node_js
-#before_install:
-#- npm i -g npm@6.4.1
-#- npm install -g typescript
 stages:
 - test
 - publish-edge
-#- name: publish-edge
-#  if: "(NOT type IN (pull_request)) AND (branch = develop)"
+- name: publish-edge
+  if: "(NOT type IN (pull_request)) AND (branch = develop)"
 - name: publish-latest
   if: branch =~ ^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)$
 jobs:
@@ -26,8 +23,7 @@ jobs:
       skip_cleanup: true
       script: "./scripts/publish-edge.sh"
       on:
-        all_branches: true
-#          branch: develop
+        branch: develop
   - stage: publish-latest
     name: Publish @latest to NPM
     script:

--- a/scripts/functions.sh
+++ b/scripts/functions.sh
@@ -57,15 +57,15 @@ check_head() {
 
 check_version() {
   echo "  Checking if version of tag matches version in package.json..."
-  if ! [ "$TRAVIS_TAG" = "$(npm run current-version --silent)" ]; then
+  if ! [ "$TRAVIS_TAG" = "$(yarn current-version --silent)" ]; then
     echo "✖ Tag does not match the version in package.json!"
     echo "  - Tag: $TRAVIS_TAG"
-    echo "  - Version: $(npm run current-version --silent)"
+    echo "  - Version: $(yarn current-version --silent)"
     return 1
   fi
   echo "✔ Tag matches version in package.json"
   echo "  - Tag: $TRAVIS_TAG"
-  echo "  - Version: $(npm run current-version --silent)"
+  echo "  - Version: $(yarn current-version --silent)"
   return 0
 }
 

--- a/scripts/functions.sh
+++ b/scripts/functions.sh
@@ -87,7 +87,7 @@ publish_edge() {
   update_package_json "$new_version"
   git commit -a -m "Updating version [skip ci]"
   cp .npmrc.template "$HOME"/.npmrc
-  npm publish --tag edge --dry-run || return 1
+  npm publish --tag edge || return 1
   rm package.json.bak
 
   echo "✔ Published edge release"
@@ -97,7 +97,7 @@ publish_latest() {
   echo "  Publishing new release to NPM..."
 
   cp .npmrc.template "$HOME"/.npmrc
-  npm publish
+  npm publish || return 1
 
   echo "✔ Published new release"
 }

--- a/scripts/functions.sh
+++ b/scripts/functions.sh
@@ -87,9 +87,7 @@ publish_edge() {
   update_package_json "$new_version"
   git commit -a -m "Updating version [skip ci]"
   cp .npmrc.template "$HOME"/.npmrc
-  npm publish --tag edge
-
-
+  npm publish --tag edge --dry-run || return 1
   rm package.json.bak
 
   echo "✔ Published edge release"

--- a/scripts/rm-build.js
+++ b/scripts/rm-build.js
@@ -28,6 +28,7 @@ const rmdirs = async (dir) => {
   const buildItems = fs.readdirSync(process.cwd())
   for (const buildItem of buildItems) {
     if (buildItem.startsWith('index.')) {
+      console.log('unlinking (outside):', `${process.cwd()}/${buildItem}`)
       fs.unlinkSync(`${process.cwd()}/${buildItem}`)
     } else if (buildItem.match(/^v([0-9]+)+(\.[0-9]+)+(-[a-zA-Z0-9-_]+)?/g)) {
       // Matches 'v' followed by digits separated by dots followed by an optional '-tag'

--- a/scripts/rm-build.js
+++ b/scripts/rm-build.js
@@ -7,16 +7,12 @@ const rmdir = promisify(fs.rmdir)
 const unlink = promisify(fs.unlink)
 
 const rmdirs = async (dir) => {
-    console.log("  dir:", dir)
   let entries = await readdir(dir, { withFileTypes: true })
   for (const entry of entries) {
-    console.log("  entry:", entry)
     let fullPath = path.join(dir, entry.name)
     if (entry.isDirectory()) {
-      console.log("recursing:", fullPath)
       await rmdirs(fullPath)
     } else {
-      console.log("unlinking:", fullPath)
       await unlink(fullPath)
     }
   }

--- a/scripts/rm-build.js
+++ b/scripts/rm-build.js
@@ -24,15 +24,14 @@ const rmdirs = async (dir) => {
 }
 
 (async () => {
-  console.log("process.cwd():", process.cwd())
-  const buildItems = fs.readdirSync(process.cwd())
+  const buildItems = await readdir(process.cwd(), { withFileTypes: true })
   for (const buildItem of buildItems) {
-    if (buildItem.startsWith('index.')) {
-      console.log('unlinking (outside):', `${process.cwd()}/${buildItem}`)
-      fs.unlinkSync(`${process.cwd()}/${buildItem}`)
-    } else if (buildItem.match(/^v([0-9]+)+(\.[0-9]+)+(-[a-zA-Z0-9-_]+)?/g)) {
+    const fullPath = path.join(process.cwd(), buildItem.name)
+    if (buildItem.name.startsWith('index.')) {
+      await unlink(fullPath)
+    } else if (buildItem.name.match(/^v([0-9]+)+(\.[0-9]+)+(-[a-zA-Z0-9-_]+)?/g)) {
       // Matches 'v' followed by digits separated by dots followed by an optional '-tag'
-      await rmdirs(`${process.cwd()}/${buildItem}`)
+      await rmdirs(fullPath)
     }
   }
 })()

--- a/scripts/rm-build.js
+++ b/scripts/rm-build.js
@@ -7,12 +7,16 @@ const rmdir = promisify(fs.rmdir)
 const unlink = promisify(fs.unlink)
 
 const rmdirs = async (dir) => {
+    console.log("  dir:", dir)
   let entries = await readdir(dir, { withFileTypes: true })
   for (const entry of entries) {
+    console.log("  entry:", entry)
     let fullPath = path.join(dir, entry.name)
     if (entry.isDirectory()) {
+      console.log("recursing:", fullPath)
       await rmdirs(fullPath)
     } else {
+      console.log("unlinking:", fullPath)
       await unlink(fullPath)
     }
   }
@@ -20,6 +24,7 @@ const rmdirs = async (dir) => {
 }
 
 (async () => {
+  console.log("process.cwd():", process.cwd())
   const buildItems = fs.readdirSync(process.cwd())
   for (const buildItem of buildItems) {
     if (buildItem.startsWith('index.')) {


### PR DESCRIPTION
Since .travis.yml specified a node version, it would use this version instead of the .nvmrc specified verison. This caused the publish step to use an older version of Node, which had a different `fs` module, thus failing on the build step. By removing the node version from .travis.yml, Travis automatically uses the .nvmrc version.

Additional changes:
- Changed all `npm run` calls to `yarn`
- Made sure that the build fails correctly when publish fails
- Normalize the fs/path function usage in `scripts/rm-build.js`