### PR TITLE
Create indices for faster reading of blocks from pgfill database

### DIFF
--- a/src/v1.7/readers/state-history/StateHistoryPostgresActionReader.ts
+++ b/src/v1.7/readers/state-history/StateHistoryPostgresActionReader.ts
@@ -96,8 +96,20 @@ export class StateHistoryPostgresActionReader extends AbstractActionReader {
         await pgMonitor.attach(this.massiveInstance.driverConfig)
       }
       this.db = this.massiveInstance[this.dbSchema]
+      await this.addDbIndex('action_trace', 'transaction_id', 'transaction_id_idx1')
+      await this.addDbIndex('action_trace_authorization', 'transaction_id', 'transaction_id_idx2')
     } catch (err) {
       throw new NotInitializedError('', err)
+    }
+  }
+
+  protected async addDbIndex(tableName: string, columnName: string, indexName: string = `${columnName}_idx`) {
+    if (this.massiveInstance) {
+      await this.massiveInstance.query(`
+        CREATE INDEX IF NOT EXISTS ${indexName} ON ${this.dbSchema}.${tableName} (${columnName})
+      `)
+    } else {
+      throw Error('this.massiveInstance should already be set.')
     }
   }
 }

--- a/src/v1.8/readers/state-history/StateHistoryPostgresActionReader.ts
+++ b/src/v1.8/readers/state-history/StateHistoryPostgresActionReader.ts
@@ -108,8 +108,20 @@ export class StateHistoryPostgresActionReader extends AbstractActionReader {
         await pgMonitor.attach(this.massiveInstance.driverConfig)
       }
       this.db = this.massiveInstance[this.dbSchema]
+      await this.addDbIndex('action_trace', 'transaction_id', 'transaction_id_idx1')
+      await this.addDbIndex('action_trace_authorization', 'transaction_id', 'transaction_id_idx2')
     } catch (err) {
       throw new NotInitializedError('', err)
+    }
+  }
+
+  protected async addDbIndex(tableName: string, columnName: string, indexName: string = `${columnName}_idx`) {
+    if (this.massiveInstance) {
+      await this.massiveInstance.query(`
+        CREATE INDEX IF NOT EXISTS ${indexName} ON ${this.dbSchema}.${tableName} (${columnName})
+      `)
+    } else {
+      throw Error('this.massiveInstance should already be set.')
     }
   }
 }


### PR DESCRIPTION
- ≈10X performance gain on reading blocks from pgfill database by adding indices on `action_trace` and `action_trace_authorization` tables' `transaction_id` columns.