### PR TITLE
Support a '.' in Demux subscription

### DIFF
--- a/src/v1.7/handlers/massiveeos/MassiveEosActionHandler.test.ts
+++ b/src/v1.7/handlers/massiveeos/MassiveEosActionHandler.test.ts
@@ -25,6 +25,7 @@ describe('MassiveEosActionHandler', () => {
       'contract::action>notified',
       'contract::action>*',
       '*::*>*',
+      'hasa.dot::action'
     ]
 
     const shouldFail = [
@@ -38,6 +39,13 @@ describe('MassiveEosActionHandler', () => {
       'blank::>action',
       'asterisks::**',
       'asterisks2::*abc',
+      'has..two::dots',
+      'has.two.dots::separated',
+      '.startswith::dot',
+      'endswith.::dot',
+      'dotwith.*::asterisk',
+      '*.dotwith::asterisk',
+      '*.*::2astwithdot',
     ]
 
     it('all passes validation', () => {

--- a/src/v1.7/handlers/massiveeos/MassiveEosActionHandler.ts
+++ b/src/v1.7/handlers/massiveeos/MassiveEosActionHandler.ts
@@ -66,7 +66,15 @@ export class MassiveEosActionHandler extends MassiveActionHandler {
    * @param actionType
    */
   protected validateActionType(actionType: string) {
-    const validationRegex = /^([a-z12345]{1,12}|\*)::([a-z12345]{1,12}|\*)(>([a-z12345]{1,12}|\*))?$/g
+                         // 1 to 12 characters with a possible '.' in the middle, or '*'
+    const matchPattern = '^((?=.{1,12}:)([a-z12345]+\\.?[a-z12345]+)|\\*)' +
+                         // Delimiter
+                         '::' +
+                         // 1 to 12 characters, or '*'
+                         '([a-z12345]{1,12}|\\*)' +
+                         // (Optional) '>' followed by: 1 to 12 characters, or '*'
+                         '(>([a-z12345]{1,12}|\\*))?$'
+    const validationRegex = new RegExp(matchPattern)
     return !!actionType.match(validationRegex)
   }
 }


### PR DESCRIPTION
`MassiveEosActionHandler`: This fixes the validation of subscription to allow a single `.` in the contract portion of the subscription string, i.e. `eosio.token::transfer`.