### PR TITLE
Normalize block hash hex casing to lowercase

### DIFF
--- a/src/v1.7/readers/state-history/StateHistoryPostgresBlock.ts
+++ b/src/v1.7/readers/state-history/StateHistoryPostgresBlock.ts
@@ -46,8 +46,8 @@ export class StateHistoryPostgresBlock implements Block {
   ) {
     this.blockInfo = {
       blockNumber: Number(rawBlockInfo.block_index),
-      blockHash: rawBlockInfo.block_id,
-      previousBlockHash: rawBlockInfo.previous,
+      blockHash: rawBlockInfo.block_id.toLowerCase(),
+      previousBlockHash: rawBlockInfo.previous.toLowerCase(),
       timestamp: rawBlockInfo.timestamp,
     }
     this.warnIfNotDistinct()

--- a/src/v1.8/readers/state-history/StateHistoryPostgresBlock.ts
+++ b/src/v1.8/readers/state-history/StateHistoryPostgresBlock.ts
@@ -48,8 +48,8 @@ export class StateHistoryPostgresBlock implements Block {
   ) {
     this.blockInfo = {
       blockNumber: Number(rawBlockInfo.block_num),
-      blockHash: rawBlockInfo.block_id,
-      previousBlockHash: rawBlockInfo.previous,
+      blockHash: rawBlockInfo.block_id.toLowerCase(),
+      previousBlockHash: rawBlockInfo.previous.toLowerCase(),
       timestamp: rawBlockInfo.timestamp,
     }
     this.getContextFreeDataById()


### PR DESCRIPTION
Enables compatibility when switching between action readers.