### PR TITLE
Bump typescript

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "tslint": "^5.10.0",
     "tslint-eslint-rules": "^5.3.1",
     "typedoc": "^0.15.6",
-    "typescript": "~3.5.3"
+    "typescript": "^3.7.5"
   },
   "dependencies": {
     "@types/express": "4.16.1",
@@ -53,7 +53,7 @@
     "lodash": "4.17.15"
   },
   "scripts": {
-    "build": "yarn rm-build && tsc",
+    "build": "yarn rm-build && yarn tsc",
     "lint": "tslint -c tslint.json -p tsconfig.json",
     "test": "yarn jest",
     "rm-build": "node ./scripts/rm-build.js",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4632,10 +4632,10 @@ typescript@3.7.x:
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.7.4.tgz#1743a5ec5fef6a1fa9f3e4708e33c81c73876c19"
   integrity sha512-A25xv5XCtarLwXpcDNZzCGvW2D1S3/bACratYBx2sax8PefsFhlYmkQicKHvpYflFS8if4zne5zT5kpJ7pzuvw==
 
-typescript@~3.5.3:
-  version "3.5.3"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.5.3.tgz#c830f657f93f1ea846819e929092f5fe5983e977"
-  integrity sha512-ACzBtm/PhXBDId6a6sDJfroT2pOWt/oOnk4/dElG5G33ZL776N3Y6/6bKZJBFpd+b05F3Ct9qDjMeJmRWtE2/g==
+typescript@^3.7.5:
+  version "3.7.5"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.7.5.tgz#0692e21f65fd4108b9330238aac11dd2e177a1ae"
+  integrity sha512-/P5lkRXkWHNAbcJIiHPfRoKqyd7bsyCma1hZNUGfn20qm64T6ZBlrzprymeu918H+mB/0rIg2gGK/BXkhhYgBw==
 
 uglify-js@^3.1.4:
   version "3.7.3"


### PR DESCRIPTION
- Bump Typescript version to `3.5.7` to resolve type error during build
- Make sure installed `node_modules` Typescript is used when running `yarn build`