### PR TITLE
Introduce TraceActionReader

### DIFF
--- a/src/v1.7/readers/nodeos/NodeosBlock.ts
+++ b/src/v1.7/readers/nodeos/NodeosBlock.ts
@@ -7,7 +7,7 @@ export class NodeosBlock implements Block {
   public blockInfo: BlockInfo
   constructor(
     rawBlock: any,
-    private log: Logger
+    protected log: Logger
   ) {
     this.blockInfo = {
       blockNumber: rawBlock.block_num,
@@ -51,7 +51,7 @@ export class NodeosBlock implements Block {
     }))
   }
 
-  private flattenArray(arr: any[]): any[] {
+  protected flattenArray(arr: any[]): any[] {
     return arr.reduce((flat, toFlatten) =>
       flat.concat(Array.isArray(toFlatten) ? this.flattenArray(toFlatten) : toFlatten), [])
   }

--- a/src/v1.8/index.ts
+++ b/src/v1.8/index.ts
@@ -13,3 +13,4 @@ export {
 
 // export from this version if changed
 export { StateHistoryPostgresActionReader } from './readers/state-history'
+export { TraceActionReader } from './readers/trace'

--- a/src/v1.8/readers/trace/TraceActionReader.ts
+++ b/src/v1.8/readers/trace/TraceActionReader.ts
@@ -2,11 +2,11 @@ import { NodeosActionReader } from '../../../v1.7/readers/nodeos/NodeosActionRea
 import { retry } from '../../../v1.7/utils'
 import request from 'request-promise-native'
 import { RetrieveBlockError } from '../../../v1.7/errors'
-import { NodeosActionReaderOptions } from '../../../v1.7/interfaces'
+import { TraceActionReaderOptions } from './interfaces'
 import { TraceBlock } from './TraceBlock'
 
 export class TraceActionReader extends NodeosActionReader {
-  constructor(options: NodeosActionReaderOptions) {
+  constructor(options: TraceActionReaderOptions) {
     super(options)
   }
 

--- a/src/v1.8/readers/trace/TraceActionReader.ts
+++ b/src/v1.8/readers/trace/TraceActionReader.ts
@@ -2,11 +2,11 @@ import { NodeosActionReader } from '../../../v1.7/readers/nodeos/NodeosActionRea
 import { retry } from '../../../v1.7/utils'
 import request from 'request-promise-native'
 import { RetrieveBlockError } from '../../../v1.7/errors'
-import { TraceActionReaderOptions } from './interfaces'
+import { NodeosActionReaderOptions } from '../../../v1.7/interfaces'
 import { TraceBlock } from './TraceBlock'
 
 export class TraceActionReader extends NodeosActionReader {
-  constructor(options: TraceActionReaderOptions) {
+  constructor(options: NodeosActionReaderOptions) {
     super(options)
   }
 

--- a/src/v1.8/readers/trace/TraceActionReader.ts
+++ b/src/v1.8/readers/trace/TraceActionReader.ts
@@ -1,0 +1,29 @@
+import { NodeosActionReader } from '../../../v1.7/readers/nodeos/NodeosActionReader'
+import { retry } from '../../../v1.7/utils'
+import request from 'request-promise-native'
+import { RetrieveBlockError } from '../../../v1.7/errors'
+import { TraceActionReaderOptions } from './interfaces'
+import { TraceBlock } from './TraceBlock'
+
+export class TraceActionReader extends NodeosActionReader {
+  constructor(options: TraceActionReaderOptions) {
+    super(options)
+  }
+
+  public async getBlock(blockNumber: number, numRetries: number = 120, waitTimeMs: number = 250): Promise<TraceBlock> {
+    try {
+      const block = await retry(async () => {
+        const rawBlock = await request.post({
+          url: `${this.nodeosEndpoint}/v1/trace_api/get_block`,
+          json: { block_num: blockNumber },
+        })
+        return new TraceBlock(rawBlock, this.log)
+      }, numRetries, waitTimeMs)
+
+      return block
+    } catch (err) {
+      this.log.error(err)
+      throw new RetrieveBlockError()
+    }
+  }
+}

--- a/src/v1.8/readers/trace/TraceBlock.ts
+++ b/src/v1.8/readers/trace/TraceBlock.ts
@@ -1,0 +1,28 @@
+import { NodeosBlock } from '../../../v1.7/readers/nodeos/NodeosBlock'
+import { EosAction } from '../../../v1.7/interfaces'
+
+export class TraceBlock extends NodeosBlock {
+  protected collectActionsFromBlock(rawBlock: any): EosAction[] {
+    const producer = rawBlock.producer
+    return this.flattenArray(rawBlock.transactions.map((transaction: any, index: number) => {
+        return transaction.trx.transaction.actions.map((action: any, actionIndex: number) => {
+        if (typeof action.data === "string") {
+          this.log.warn(
+            `Action data for '${action.receiver}::${action.action}' not deserialized ` +
+            `(block ${this.blockInfo.blockNumber}, transaction index ${index}, action index ${actionIndex})`
+          )
+        }
+        const block = {
+          type: `${action.receiver}::${action.action}`,
+          payload: {
+            producer,
+            transactionId: transaction.id,
+            actionIndex,
+            ...action,
+          },
+        }
+        return block
+      })
+    }))
+  }
+}

--- a/src/v1.8/readers/trace/TraceBlock.ts
+++ b/src/v1.8/readers/trace/TraceBlock.ts
@@ -8,9 +8,9 @@ export class TraceBlock extends NodeosBlock {
     this.blockInfo.previousBlockHash = rawBlock.previous_id
     //
     const producer = rawBlock.producer
-    return this.flattenArray(rawBlock.transactions.map((transaction: any, index: number) => {
-        return transaction.actions.map((action: any, actionIndex: number) => {
-        if (typeof action.data === "string") {
+    return this.flattenArray(rawBlock.transactions.map((transaction: any, _: number) => {
+      return transaction.actions.map((action: any, actionIndex: number) => {
+        if (typeof action.data === 'string') {
           // TODO: action data deserialization when abi is provided
         }
         const block = {

--- a/src/v1.8/readers/trace/TraceBlock.ts
+++ b/src/v1.8/readers/trace/TraceBlock.ts
@@ -3,14 +3,15 @@ import { EosAction } from '../../../v1.7/interfaces'
 
 export class TraceBlock extends NodeosBlock {
   protected collectActionsFromBlock(rawBlock: any): EosAction[] {
+    // workaround fix
+    this.blockInfo.blockNumber = rawBlock.number
+    this.blockInfo.previousBlockHash = rawBlock.previous_id
+    //
     const producer = rawBlock.producer
     return this.flattenArray(rawBlock.transactions.map((transaction: any, index: number) => {
-        return transaction.trx.transaction.actions.map((action: any, actionIndex: number) => {
+        return transaction.actions.map((action: any, actionIndex: number) => {
         if (typeof action.data === "string") {
-          this.log.warn(
-            `Action data for '${action.receiver}::${action.action}' not deserialized ` +
-            `(block ${this.blockInfo.blockNumber}, transaction index ${index}, action index ${actionIndex})`
-          )
+          // TODO: action data deserialization when abi is provided
         }
         const block = {
           type: `${action.receiver}::${action.action}`,

--- a/src/v1.8/readers/trace/index.ts
+++ b/src/v1.8/readers/trace/index.ts
@@ -1,0 +1,1 @@
+export { TraceActionReader } from './TraceActionReader'

--- a/src/v1.8/readers/trace/interfaces.ts
+++ b/src/v1.8/readers/trace/interfaces.ts
@@ -1,0 +1,5 @@
+import { NodeosActionReaderOptions } from '../../../v1.7/interfaces'
+
+// tslint:disable-next-line
+export interface TraceActionReaderOptions extends NodeosActionReaderOptions {
+}

--- a/src/v1.8/readers/trace/interfaces.ts
+++ b/src/v1.8/readers/trace/interfaces.ts
@@ -1,4 +1,0 @@
-import { NodeosActionReaderOptions } from '../../../v1.7/interfaces'
-
-export interface TraceActionReaderOptions extends NodeosActionReaderOptions {
-}

--- a/src/v1.8/readers/trace/interfaces.ts
+++ b/src/v1.8/readers/trace/interfaces.ts
@@ -1,0 +1,4 @@
+import { NodeosActionReaderOptions } from '../../../v1.7/interfaces'
+
+export interface TraceActionReaderOptions extends NodeosActionReaderOptions {
+}


### PR DESCRIPTION
TraceActionReader is an action reader which works with nodeos which activates eosio::trace_api_plugin. User can read the traces for inline actions easily without building separated complex history solutions.